### PR TITLE
Freebsd compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,7 @@ mpc-${VERSION_MPC}: mpc-${VERSION_MPC}.tar.gz
 
 mintbin-CVS-${VERSION_MINTBIN}: mintbin-CVS-${VERSION_MINTBIN}.tar.gz
 	tar xzf mintbin-CVS-${VERSION_MINTBIN}.tar.gz
+	cd $@ && patch -p1 < ../mintbin.patch
 	touch $@
 	
 pml-${VERSION_PML}: pml-${VERSION_PML}.tar.bz2 pml-${VERSION_PML}-mint-${PATCH_PML}.patch.bz2

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,8 @@ gcc-${VERSION_GCC}-${CPU}-cross: gcc-${VERSION_GCC}
 # Shortcuts
 
 gcc-multilib-patch: gcc-${VERSION_GCC}
-	sed -i -e "s:\(MULTILIB_OPTIONS =\).*:\1 ${OPTS}:" -e "s:\(MULTILIB_DIRNAMES =\).*:\1 ${DIRS}:" gcc-${VERSION_GCC}/gcc/config/m68k/t-mint
+	sed -e "s:\(MULTILIB_OPTIONS =\).*:\1 ${OPTS}:" -e "s:\(MULTILIB_DIRNAMES =\).*:\1 ${DIRS}:" gcc-${VERSION_GCC}/gcc/config/m68k/t-mint > t-mint.patched
+	mv t-mint.patched gcc-${VERSION_GCC}/gcc/config/m68k/t-mint
 
 gcc-preliminary: gcc-${VERSION_GCC}-${CPU}-cross
 

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,8 @@ mintbin-CVS-${VERSION_MINTBIN}: mintbin-CVS-${VERSION_MINTBIN}.tar.gz
 	
 pml-${VERSION_PML}: pml-${VERSION_PML}.tar.bz2 pml-${VERSION_PML}-mint-${PATCH_PML}.patch.bz2
 	tar xjf pml-${VERSION_PML}.tar.bz2
-	cd $@ && bzcat ../pml-${VERSION_PML}-mint-${PATCH_PML}.patch.bz2 | patch -p1 && cat ../pml.patch | patch -p1 && cd ..
+	cd $@ && bzcat ../pml-${VERSION_PML}-mint-${PATCH_PML}.patch.bz2 | patch -p1
+	cd $@ && cat ../pml.patch | patch -p1
 	touch $@
 
 # Building

--- a/Makefile
+++ b/Makefile
@@ -135,8 +135,8 @@ mintlib: mintlib-CVS-${VERSION_MINTLIB}
 	$(MAKE) clean && \
 	export GCC_BUILD_DIR="${PWD}/gcc-${VERSION_GCC}-${CPU}-cross" && export PATH=${INSTALL_DIR}/bin:$$PATH && \
 	echo "$$GCC_BUILD_DIR/gcc/include -I$$GCC_BUILD_DIR/gcc/include-fixed" > includepath && \
-	$(MAKE) SHELL=/bin/bash CROSS=yes WITH_020_LIB=no WITH_V4E_LIB=no CC="$$GCC_BUILD_DIR/gcc/xgcc -B$$GCC_BUILD_DIR/gcc/ -B${INSTALL_DIR}/bin/ -B${INSTALL_DIR}/lib/ -isystem ${INSTALL_DIR}/include -isystem ${INSTALL_DIR}/sys-include" && \
-	$(MAKE) SHELL=/bin/bash CROSS=yes WITH_020_LIB=no WITH_V4E_LIB=no install && \
+	$(MAKE) SHELL=$(BASH) CROSS=yes WITH_020_LIB=no WITH_V4E_LIB=no CC="$$GCC_BUILD_DIR/gcc/xgcc -B$$GCC_BUILD_DIR/gcc/ -B${INSTALL_DIR}/bin/ -B${INSTALL_DIR}/lib/ -isystem ${INSTALL_DIR}/include -isystem ${INSTALL_DIR}/sys-include" && \
+	$(MAKE) SHELL=$(BASH) CROSS=yes WITH_020_LIB=no WITH_V4E_LIB=no install && \
 	touch $@
 
 mintbin: mintbin-CVS-${VERSION_MINTBIN}

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ DOWNLOADS	= binutils-${VERSION_BINUTILS}.tar.bz2 gcc-${VERSION_GCC}.tar.bz2 \
 		  gcc-${VERSION_GCC}-mint-${PATCH_GCC}.patch.bz2 pml-${VERSION_PML}-mint-${PATCH_PML}.patch.bz2
 
 default: ./build.sh $(DOWNLOADS)
-	$(BASH) ./build.sh
+	MAKE=$(MAKE) $(BASH) ./build.sh
 
 download: $(DOWNLOADS)
 
@@ -110,8 +110,8 @@ binutils-${VERSION_BINUTILS}-${CPU}-cross: binutils-${VERSION_BINUTILS}
 	mkdir -p $@
 	cd $@ && \
 	PATH=${INSTALL_DIR}/bin:$$PATH ../binutils-${VERSION_BINUTILS}/configure --target=m68k-atari-mint --prefix=${INSTALL_DIR} --disable-nls --disable-werror && \
-	make && \
-	make install-strip
+	$(MAKE) && \
+	$(MAKE) install-strip
 
 binutils: binutils-${VERSION_BINUTILS}-${CPU}-cross
 
@@ -119,7 +119,7 @@ gcc-${VERSION_GCC}-${CPU}-cross: gcc-${VERSION_GCC}
 	mkdir -p $@
 	cd $@ && \
 	PATH=${INSTALL_DIR}/bin:$$PATH ../gcc-${VERSION_GCC}/configure --target=m68k-atari-mint --prefix=${INSTALL_DIR} --enable-languages="c,c++" --disable-nls --disable-libstdcxx-pch CFLAGS_FOR_TARGET="-O2 -fomit-frame-pointer" CXXFLAGS_FOR_TARGET="-O2 -fomit-frame-pointer" --with-cpu=${CPU} && \
-	make all-target-libgcc && \
+	$(MAKE) all-target-libgcc && \
 	cat ../gcc-${VERSION_GCC}/gcc/limitx.h ../gcc-${VERSION_GCC}/gcc/glimits.h ../gcc-${VERSION_GCC}/gcc/limity.h > gcc/include-fixed/limits.h # Dirty hack to fix the PATH_MAX issue. The good solution would be to configure gcc using --with-headers
 
 # Shortcuts
@@ -132,29 +132,29 @@ gcc-preliminary: gcc-${VERSION_GCC}-${CPU}-cross
 
 mintlib: mintlib-CVS-${VERSION_MINTLIB}
 	cd mintlib-CVS-${VERSION_MINTLIB} && \
-	make clean && \
+	$(MAKE) clean && \
 	export GCC_BUILD_DIR="${PWD}/gcc-${VERSION_GCC}-${CPU}-cross" && export PATH=${INSTALL_DIR}/bin:$$PATH && \
 	echo "$$GCC_BUILD_DIR/gcc/include -I$$GCC_BUILD_DIR/gcc/include-fixed" > includepath && \
-	make SHELL=/bin/bash CROSS=yes WITH_020_LIB=no WITH_V4E_LIB=no CC="$$GCC_BUILD_DIR/gcc/xgcc -B$$GCC_BUILD_DIR/gcc/ -B${INSTALL_DIR}/bin/ -B${INSTALL_DIR}/lib/ -isystem ${INSTALL_DIR}/include -isystem ${INSTALL_DIR}/sys-include" && \
-	make SHELL=/bin/bash CROSS=yes WITH_020_LIB=no WITH_V4E_LIB=no install && \
+	$(MAKE) SHELL=/bin/bash CROSS=yes WITH_020_LIB=no WITH_V4E_LIB=no CC="$$GCC_BUILD_DIR/gcc/xgcc -B$$GCC_BUILD_DIR/gcc/ -B${INSTALL_DIR}/bin/ -B${INSTALL_DIR}/lib/ -isystem ${INSTALL_DIR}/include -isystem ${INSTALL_DIR}/sys-include" && \
+	$(MAKE) SHELL=/bin/bash CROSS=yes WITH_020_LIB=no WITH_V4E_LIB=no install && \
 	touch $@
 
 mintbin: mintbin-CVS-${VERSION_MINTBIN}
 	cd mintbin-CVS-${VERSION_MINTBIN} && \
 	PATH=${INSTALL_DIR}/bin:$$PATH ./configure --target=m68k-atari-mint --prefix=${INSTALL_DIR} --disable-nls && \
-	make && \
-	make install && \
+	$(MAKE) && \
+	$(MAKE) install && \
 	mv ${INSTALL_DIR}/m68k-atari-mint/bin/m68k-atari-mint-* ${INSTALL_DIR}/bin
 
 pml: pml-${VERSION_PML}
 	cd pml-${VERSION_PML}/pmlsrc && \
-	make clean LIB="$(DIR)" && \
+	$(MAKE) clean LIB="$(DIR)" && \
 	export GCC_BUILD_DIR="${PWD}/gcc-${VERSION_GCC}-${CPU}-cross" && export PATH=${INSTALL_DIR}/bin:$$PATH && \
-	make AR="m68k-atari-mint-ar" CC="$$GCC_BUILD_DIR/gcc/xgcc -B$$GCC_BUILD_DIR/gcc/ -B${INSTALL_DIR}/m68k-atari-mint/bin/ -B${INSTALL_DIR}/m68k-atari-mint/lib/ -isystem ${INSTALL_DIR}/m68k-atari-mint/include" CPU="$(OPTS)" CROSSDIR="${INSTALL_DIR}/m68k-atari-mint" LIB="$(DIR)" && \
-	make install AR="m68k-atari-mint-ar" CC="$$GCC_BUILD_DIR/gcc/xgcc -B$$GCC_BUILD_DIR/gcc/ -B${INSTALL_DIR}/m68k-atari-mint/bin/ -B${INSTALL_DIR}/m68k-atari-mint/lib/ -isystem ${INSTALL_DIR}/m68k-atari-mint/include" CPU="$(OPTS)" CROSSDIR="${INSTALL_DIR}/m68k-atari-mint" LIB="$(DIR)"
+	$(MAKE) AR="m68k-atari-mint-ar" CC="$$GCC_BUILD_DIR/gcc/xgcc -B$$GCC_BUILD_DIR/gcc/ -B${INSTALL_DIR}/m68k-atari-mint/bin/ -B${INSTALL_DIR}/m68k-atari-mint/lib/ -isystem ${INSTALL_DIR}/m68k-atari-mint/include" CPU="$(OPTS)" CROSSDIR="${INSTALL_DIR}/m68k-atari-mint" LIB="$(DIR)" && \
+	$(MAKE) install AR="m68k-atari-mint-ar" CC="$$GCC_BUILD_DIR/gcc/xgcc -B$$GCC_BUILD_DIR/gcc/ -B${INSTALL_DIR}/m68k-atari-mint/bin/ -B${INSTALL_DIR}/m68k-atari-mint/lib/ -isystem ${INSTALL_DIR}/m68k-atari-mint/include" CPU="$(OPTS)" CROSSDIR="${INSTALL_DIR}/m68k-atari-mint" LIB="$(DIR)"
 
 gcc:
-	export PATH=${INSTALL_DIR}/bin:$$PATH && cd gcc-${VERSION_GCC}-${CPU}-cross && make && make install-strip
+	export PATH=${INSTALL_DIR}/bin:$$PATH && cd gcc-${VERSION_GCC}-${CPU}-cross && $(MAKE) && $(MAKE) install-strip
 
 # Atari building
 
@@ -163,8 +163,8 @@ binutils-${VERSION_BINUTILS}-${CPU}-atari: binutils-${VERSION_BINUTILS}
 	cd $@ && \
 	export PATH=${INSTALL_DIR}/bin:$$PATH && \
 	../binutils-${VERSION_BINUTILS}/configure --target=m68k-atari-mint --host=m68k-atari-mint --disable-nls --prefix=/usr CFLAGS="-O2 -fomit-frame-pointer" CXXFLAGS="-O2 -fomit-frame-pointer" && \
-	make && \
-	make install DESTDIR=${PWD}/binary-package/${CPU}/binutils-${VERSION_BINUTILS}	# make install-strip doesn't work properly
+	$(MAKE) && \
+	$(MAKE) install DESTDIR=${PWD}/binary-package/${CPU}/binutils-${VERSION_BINUTILS}	# make install-strip doesn't work properly
 
 binutils-atari: binutils-${VERSION_BINUTILS}-${CPU}-atari
 
@@ -173,8 +173,8 @@ gmp-${VERSION_GMP}-${CPU}-atari: gmp-${VERSION_GMP}
 	cd $@ && \
 	export PATH=${INSTALL_DIR}/bin:$$PATH && \
 	../gmp-${VERSION_GMP}/configure $(ASSEMBLY) --host=m68k-atari-mint --prefix=${PWD}/binary-package/${CPU}/gmp-${VERSION_GMP}/usr CFLAGS="-O2 -fomit-frame-pointer" CXXFLAGS="-O2 -fomit-frame-pointer" && \
-	make && \
-	make install-strip
+	$(MAKE) && \
+	$(MAKE) install-strip
 
 gmp-atari: gmp-${VERSION_GMP}-${CPU}-atari
 
@@ -183,8 +183,8 @@ mpfr-${VERSION_MPFR}-${CPU}-atari: mpfr-${VERSION_MPFR}
 	cd $@ && \
 	export PATH=${INSTALL_DIR}/bin:$$PATH && \
 	../mpfr-${VERSION_MPFR}/configure --host=m68k-atari-mint --with-gmp=${PWD}/binary-package/${CPU}/gmp-${VERSION_GMP}/usr --prefix=${PWD}/binary-package/${CPU}/mpfr-${VERSION_MPFR}/usr CFLAGS="-O2 -fomit-frame-pointer" CXXFLAGS="-O2 -fomit-frame-pointer" && \
-	make && \
-	make install-strip
+	$(MAKE) && \
+	$(MAKE) install-strip
 
 mpfr-atari: gmp-atari mpfr-${VERSION_MPFR}-${CPU}-atari
 
@@ -193,8 +193,8 @@ mpc-${VERSION_MPC}-${CPU}-atari: mpc-${VERSION_MPC}
 	cd $@ && \
 	export PATH=${INSTALL_DIR}/bin:$$PATH && \
 	../mpc-${VERSION_MPC}/configure --host=m68k-atari-mint --with-gmp=${PWD}/binary-package/${CPU}/gmp-${VERSION_GMP}/usr --with-mpfr=${PWD}/binary-package/${CPU}/mpfr-${VERSION_MPFR}/usr --prefix=${PWD}/binary-package/${CPU}/mpc-${VERSION_MPC}/usr CFLAGS="-O2 -fomit-frame-pointer" CXXFLAGS="-O2 -fomit-frame-pointer" --disable-shared && \
-	make && \
-	make install-strip
+	$(MAKE) && \
+	$(MAKE) install-strip
 
 mpc-atari: mpfr-atari mpc-${VERSION_MPC}-${CPU}-atari
 
@@ -203,8 +203,8 @@ gcc-${VERSION_GCC}-${CPU}-atari: gcc-${VERSION_GCC}
 	cd $@ && \
 	export PATH=${INSTALL_DIR}/bin:$$PATH && \
 	../gcc-${VERSION_GCC}/configure --target=m68k-atari-mint --host=m68k-atari-mint --enable-languages="c,c++" --disable-nls --disable-libstdcxx-pch --with-gmp=${PWD}/binary-package/${CPU}/gmp-${VERSION_GMP}/usr --with-mpfr=${PWD}/binary-package/${CPU}/mpfr-${VERSION_MPFR}/usr --with-mpc=${PWD}/binary-package/${CPU}/mpc-${VERSION_MPC}/usr --prefix=/usr CFLAGS="-O2 -fomit-frame-pointer" CXXFLAGS="-O2 -fomit-frame-pointer" --with-cpu=${CPU} && \
-	make && \
-	make install-strip DESTDIR=${PWD}/binary-package/${CPU}/gcc-${VERSION_GCC}
+	$(MAKE) && \
+	$(MAKE) install-strip DESTDIR=${PWD}/binary-package/${CPU}/gcc-${VERSION_GCC}
 
 gcc-atari: mpc-atari gcc-${VERSION_GCC}-${CPU}-atari
 

--- a/build.sh
+++ b/build.sh
@@ -14,9 +14,9 @@ do
 	
 	multilib_opts="$(echo "${CPU_OPTS[@]}" | sed "s/${CPU_OPTS[i]}//;" | xargs | tr ' ' '/') mshort"
 	multilib_dirs="$(echo "${CPU_DIRS[@]}" | sed "s/${CPU_DIRS[i]}//;" | xargs) mshort"
-	make gcc-multilib-patch OPTS="$multilib_opts" DIRS="$multilib_dirs" || exit 1
+	${MAKE} gcc-multilib-patch OPTS="$multilib_opts" DIRS="$multilib_dirs" || exit 1
 	
-	make binutils gcc-preliminary INSTALL_DIR="$INSTALL_DIR/$dir" CPU="$cpu" || exit 1
+	${MAKE} binutils gcc-preliminary INSTALL_DIR="$INSTALL_DIR/$dir" CPU="$cpu" || exit 1
 	for j in $indices
 	do
 		target="${CPU_DIRS[j]}"
@@ -25,26 +25,26 @@ do
 		then
 			target=""
 		fi
-		make mintlib prefix="$prefix" libdir="$prefix/lib/$target" cflags="-${CPU_OPTS[j]}" INSTALL_DIR="$INSTALL_DIR/$dir" CPU="$cpu" || exit 1
-		make pml OPTS="-${CPU_OPTS[j]}" DIR="$target" INSTALL_DIR="$INSTALL_DIR/$dir" CPU="$cpu" || exit 1
+		${MAKE} mintlib prefix="$prefix" libdir="$prefix/lib/$target" cflags="-${CPU_OPTS[j]}" INSTALL_DIR="$INSTALL_DIR/$dir" CPU="$cpu" || exit 1
+		${MAKE} pml OPTS="-${CPU_OPTS[j]}" DIR="$target" INSTALL_DIR="$INSTALL_DIR/$dir" CPU="$cpu" || exit 1
 	done
-	make gcc mintbin INSTALL_DIR="$INSTALL_DIR/$dir" CPU="$cpu" || exit 1
+	${MAKE} gcc mintbin INSTALL_DIR="$INSTALL_DIR/$dir" CPU="$cpu" || exit 1
 	
-	make binutils-atari INSTALL_DIR="$INSTALL_DIR/$dir" CPU="$cpu" || exit 1
+	${MAKE} binutils-atari INSTALL_DIR="$INSTALL_DIR/$dir" CPU="$cpu" || exit 1
 	if [ "$cpu" == "5475" ]
 	then
 		assembly="--disable-assembly"
 	else
 		assembly=""
 	fi
-	make gcc-atari ASSEMBLY="$assembly" INSTALL_DIR="$INSTALL_DIR/$dir" CPU="$cpu" || exit 1
+	${MAKE} gcc-atari ASSEMBLY="$assembly" INSTALL_DIR="$INSTALL_DIR/$dir" CPU="$cpu" || exit 1
 	
 done
 
-make strip-atari INSTALL_DIR="$INSTALL_DIR/${CPU_DIRS[0]}"	# use either 'strip'
+${MAKE} strip-atari INSTALL_DIR="$INSTALL_DIR/${CPU_DIRS[0]}"	# use either 'strip'
 
 for i in $indices
 do
 	cpu="${CPU_CPUS[i]}"
-	make pack-atari INSTALL_DIR="$INSTALL_DIR/$dir" CPU="$cpu" || exit 1
+	${MAKE} pack-atari INSTALL_DIR="$INSTALL_DIR/$dir" CPU="$cpu" || exit 1
 done

--- a/mintbin.patch
+++ b/mintbin.patch
@@ -1,0 +1,25 @@
+diff -ru mintbin-CVS-20110527-old/config.h.in mintbin-CVS-20110527/config.h.in
+--- mintbin-CVS-20110527-old/config.h.in	2011-05-27 19:41:38.000000000 +0200
++++ mintbin-CVS-20110527/config.h.in	2016-12-21 15:04:52.969504000 +0100
+@@ -156,6 +156,9 @@
+ /* Define if you have the strstr function.  */
+ #undef HAVE_STRSTR
+ 
++/* Define if you have the strerror function.  */
++#undef HAVE_STRERROR
++
+ /* Define if you have the strtol function.  */
+ #undef HAVE_STRTOL
+ 
+diff -ru mintbin-CVS-20110527-old/configure mintbin-CVS-20110527/configure
+--- mintbin-CVS-20110527-old/configure	2011-05-27 19:41:38.000000000 +0200
++++ mintbin-CVS-20110527/configure	2016-12-21 14:58:14.059416000 +0100
+@@ -2290,7 +2290,7 @@
+ fi
+ 
+ 
+-for ac_func in stpcpy strcasecmp strncasecmp strtol strtoul strstr
++for ac_func in stpcpy strcasecmp strncasecmp strtol strtoul strstr strerror
+ do
+ echo $ac_n "checking for $ac_func""... $ac_c" 1>&6
+ echo "configure:2297: checking for $ac_func" >&5

--- a/pml.patch
+++ b/pml.patch
@@ -8,6 +8,34 @@ diff -ru pml-2.03-old/pmlsrc/Makefile pml-2.03/pmlsrc/Makefile
  CROSSBIN = $(CROSSDIR)/bin
  CROSSINC = $(CROSSDIR)/include
  WITH_SHORT_LIBS = 0
+@@ -13,13 +13,13 @@
+ all : $(ALL)
+ 
+ libpml32.a :
+-	make -f Makefile.32 clean
+-	make -f Makefile.32 libpml32.a
++	$(MAKE) -f Makefile.32 clean
++	$(MAKE) -f Makefile.32 libpml32.a
+ 
+ ifeq ($(WITH_SHORT_LIBS), 1)
+ libpml.a :
+-	make -f Makefile.16 clean
+-	make -f Makefile.16 libpml.a
++	$(MAKE) -f Makefile.16 clean
++	$(MAKE) -f Makefile.16 libpml.a
+ endif
+ 
+ install : $(ALL)
+@@ -33,7 +33,7 @@
+ 	cp math.h $(CROSSINC)
+ 
+ clean:
+-	make -f Makefile.32 clean
++	$(MAKE) -f Makefile.32 clean
+ ifeq ($(WITH_SHORT_LIBS), 1)
+-	make -f Makefile.16 clean
++	$(MAKE) -f Makefile.16 clean
+ endif
 diff -ru pml-2.03-old/pmlsrc/Makefile.16 pml-2.03/pmlsrc/Makefile.16
 --- pml-2.03-old/pmlsrc/Makefile.16	2013-11-21 11:23:11.379062834 +1000
 +++ pml-2.03/pmlsrc/Makefile.16	2013-11-21 12:46:21.117142611 +1000


### PR DESCRIPTION
modifications to allow build under FreeBSD 10.3 amd64
to be tested under linux

Major changes : 
allow use of another make command than "make" (gmake under FreeBSD)
allow another bash than /bin/bash